### PR TITLE
restore v1.4 behavior

### DIFF
--- a/lib/api/html/class-beans-attribute.php
+++ b/lib/api/html/class-beans-attribute.php
@@ -117,10 +117,17 @@ final class _Beans_Attribute {
 	 */
 	public function replace( array $attributes ) {
 
-		if ( $this->has_attribute( $attributes ) && ! empty( $this->value ) ) {
+		if ( $this->new_value ) {
+
+		    if ( isset( $attributes[ $this->attribute ] ) ) {
 			$attributes[ $this->attribute ] = $this->replace_value( $attributes[ $this->attribute ] );
-		} else {
+		    } else {
 			$attributes[ $this->attribute ] = $this->new_value;
+		    }   
+		} else {
+
+		    $attributes[ $this->attribute ] = $this->value;
+
 		}
 
 		return $attributes;


### PR DESCRIPTION
In Beans v1.4, it was possible to call beans_replace_attribute with an empty "new_value" which replaced all values of the attribute with "value".

This behavior was broken in version 1.5.x 